### PR TITLE
chore: initialize Next.js project skeleton

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["next/core-web-vitals"]
+}

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "semi": false,
+  "singleQuote": true
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,0 +1,15 @@
+import './globals.css'
+import { ReactNode } from 'react'
+
+export const metadata = {
+  title: 'RSS Reader',
+  description: 'Simple RSS reader'
+}
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <h1 className="text-2xl font-bold">RSS Reader</h1>
+}

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -1,0 +1,20 @@
+import * as React from 'react'
+import { cn } from '@/lib/utils'
+
+export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {}
+
+export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, ...props }, ref) => {
+    return (
+      <button
+        ref={ref}
+        className={cn(
+          'inline-flex items-center justify-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-white hover:bg-primary/90',
+          className
+        )}
+        {...props}
+      />
+    )
+  }
+)
+Button.displayName = 'Button'

--- a/components/ui/card.tsx
+++ b/components/ui/card.tsx
@@ -1,0 +1,25 @@
+import * as React from 'react'
+import { cn } from '@/lib/utils'
+
+export const Card = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div
+      ref={ref}
+      className={cn('rounded-lg border bg-card text-card-foreground shadow-sm', className)}
+      {...props}
+    />
+  )
+)
+Card.displayName = 'Card'
+
+export const CardHeader = (
+  { className, ...props }: React.HTMLAttributes<HTMLDivElement>
+) => <div className={cn('flex flex-col space-y-1.5 p-6', className)} {...props} />
+
+export const CardTitle = (
+  { className, ...props }: React.HTMLAttributes<HTMLHeadingElement>
+) => <h3 className={cn('text-2xl font-semibold leading-none tracking-tight', className)} {...props} />
+
+export const CardContent = (
+  { className, ...props }: React.HTMLAttributes<HTMLDivElement>
+) => <div className={cn('p-6 pt-0', className)} {...props} />

--- a/components/ui/scroll-area.tsx
+++ b/components/ui/scroll-area.tsx
@@ -1,0 +1,8 @@
+import * as React from 'react'
+import { cn } from '@/lib/utils'
+
+export interface ScrollAreaProps extends React.HTMLAttributes<HTMLDivElement> {}
+
+export function ScrollArea({ className, ...props }: ScrollAreaProps) {
+  return <div className={cn('overflow-auto', className)} {...props} />
+}

--- a/components/ui/separator.tsx
+++ b/components/ui/separator.tsx
@@ -1,0 +1,8 @@
+import * as React from 'react'
+import { cn } from '@/lib/utils'
+
+export interface SeparatorProps extends React.HTMLAttributes<HTMLDivElement> {}
+
+export const Separator = ({ className, ...props }: SeparatorProps) => (
+  <div className={cn('shrink-0 bg-border h-px w-full', className)} {...props} />
+)

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,0 +1,6 @@
+import { type ClassValue, clsx } from 'clsx'
+import { twMerge } from 'tailwind-merge'
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs))
+}

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,0 +1,9 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+  experimental: {
+    appDir: true
+  }
+}
+
+export default nextConfig

--- a/package.json
+++ b/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "rss-reader-by-spec",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint",
+    "test": "vitest"
+  },
+  "dependencies": {
+    "next": "14.2.3",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "rss-parser": "^3.12.0",
+    "@types/rss-parser": "^3.12.4",
+    "msw": "^1.2.0",
+    "class-variance-authority": "^0.7.0",
+    "clsx": "^2.0.0",
+    "tailwind-merge": "^2.2.1"
+  },
+  "devDependencies": {
+    "typescript": "5.4.0",
+    "tailwindcss": "3.4.1",
+    "postcss": "8.4.31",
+    "autoprefixer": "10.4.16",
+    "eslint": "8.57.0",
+    "eslint-config-next": "14.2.3",
+    "prettier": "3.2.5",
+    "vitest": "1.5.0",
+    "@testing-library/react": "14.1.2",
+    "@testing-library/jest-dom": "6.1.5",
+    "@testing-library/user-event": "14.4.3",
+    "@vitejs/plugin-react": "4.2.0"
+  }
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,0 +1,15 @@
+import type { Config } from 'tailwindcss'
+
+const config: Config = {
+  content: [
+    './app/**/*.{ts,tsx}',
+    './components/**/*.{ts,tsx}',
+    './pages/**/*.{ts,tsx}',
+    './lib/**/*.{ts,tsx}'
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+}
+export default config

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "target": "es2017",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "types": ["vitest/globals"],
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vitest/config'
+import react from '@vitejs/plugin-react'
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    environment: 'jsdom',
+    setupFiles: ['vitest.setup.ts']
+  }
+})

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom'


### PR DESCRIPTION
## Summary
- scaffold Next.js app with TypeScript and Tailwind
- add shadcn/ui primitives and testing setup
- configure ESLint, Prettier, and Vitest

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b9a81d9840832abff4ec773f4c57b9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 新機能
  - アプリの初期レイアウトとホームページ（「RSS Reader」見出し）を追加
  - グローバルスタイルを導入し、Tailwindによる基本デザインを適用
- 雑務
  - 開発環境を整備（Next.js設定、Tailwind/PostCSS、TypeScript、ESLint、Prettier）
  - 実行・ビルド・リント用スクリプトを追加
- テスト
  - Vitest環境を導入し、Jest DOMマッチャを利用可能に設定

<!-- end of auto-generated comment: release notes by coderabbit.ai -->