### PR TITLE
feat: implement core RSS reader functionality

### DIFF
--- a/app/api/rss/route.ts
+++ b/app/api/rss/route.ts
@@ -1,0 +1,39 @@
+import { parseRss } from '@/lib/rss-parser'
+
+const ALLOWED_HOSTS = ['ai-news.dev']
+
+function validateUrl(raw: string): URL | null {
+  if (!raw || raw.length > 2048) return null
+  try {
+    const url = new URL(raw)
+    if (!['http:', 'https:'].includes(url.protocol)) return null
+    if (!ALLOWED_HOSTS.some((h) => url.hostname.endsWith(h))) {
+      throw new Error('forbidden')
+    }
+    return url
+  } catch (err) {
+    if ((err as Error).message === 'forbidden') throw err
+    return null
+  }
+}
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url)
+  const urlParam = searchParams.get('url')
+  try {
+    const url = validateUrl(urlParam || '')
+    if (!url) {
+      return new Response('Invalid URL', { status: 400 })
+    }
+    const feed = await parseRss(url.href)
+    return new Response(JSON.stringify(feed), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' }
+    })
+  } catch (err) {
+    if ((err as Error).message === 'forbidden') {
+      return new Response('Forbidden domain', { status: 403 })
+    }
+    return new Response('Failed to fetch feed', { status: 500 })
+  }
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,3 +1,29 @@
-export default function Page() {
-  return <h1 className="text-2xl font-bold">RSS Reader</h1>
+import ArticleList from '@/components/ui/article-list'
+import ErrorBoundary from '@/components/ui/error-boundary'
+import type { Article } from '@/lib/types'
+
+async function getArticles(): Promise<Article[]> {
+  try {
+    const res = await fetch(
+      'http://localhost:3000/api/rss?url=https://ai-news.dev/feeds/',
+      { cache: 'no-store' }
+    )
+    if (!res.ok) return []
+    const data = await res.json()
+    return data.items || []
+  } catch {
+    return []
+  }
+}
+
+export default async function Page() {
+  const articles = await getArticles()
+  return (
+    <main className="p-4">
+      <h1 className="text-2xl font-bold mb-4">RSS Reader</h1>
+      <ErrorBoundary>
+        <ArticleList articles={articles} />
+      </ErrorBoundary>
+    </main>
+  )
 }

--- a/components/ui/article-card.tsx
+++ b/components/ui/article-card.tsx
@@ -1,0 +1,20 @@
+import * as React from 'react'
+import type { Article } from '@/lib/types'
+import { Card } from './card'
+import { cn } from '@/lib/utils'
+
+interface Props {
+  article: Article
+  className?: string
+}
+
+export default function ArticleCard({ article, className }: Props) {
+  return (
+    <Card className={cn('p-4', className)}>
+      <a href={article.link} className="font-semibold text-lg">
+        {article.title}
+      </a>
+      <p className="text-sm text-gray-500">{new Date(article.pubDate).toLocaleString()}</p>
+    </Card>
+  )
+}

--- a/components/ui/article-card.tsx
+++ b/components/ui/article-card.tsx
@@ -10,11 +10,18 @@ interface Props {
 
 export default function ArticleCard({ article, className }: Props) {
   return (
-    <Card className={cn('p-4', className)}>
-      <a href={article.link} className="font-semibold text-lg">
+    <div className={cn('rounded-lg border bg-white p-4 shadow-sm', className)}>
+      <a 
+        href={article.link} 
+        target="_blank" 
+        rel="noopener noreferrer"
+        className="font-semibold text-lg text-blue-600 hover:text-blue-800"
+      >
         {article.title}
       </a>
-      <p className="text-sm text-gray-500">{new Date(article.pubDate).toLocaleString()}</p>
-    </Card>
+      <p className="text-sm text-gray-500 mt-2">
+        {new Date(article.pubDate).toLocaleString()}
+      </p>
+    </div>
   )
 }

--- a/components/ui/article-detail.tsx
+++ b/components/ui/article-detail.tsx
@@ -1,0 +1,18 @@
+import * as React from 'react'
+import type { Article } from '@/lib/types'
+
+interface Props {
+  article: Article
+}
+
+export default function ArticleDetail({ article }: Props) {
+  return (
+    <article className="space-y-2">
+      <h2 className="text-xl font-bold">{article.title}</h2>
+      <div dangerouslySetInnerHTML={{ __html: article.content ?? '' }} />
+      <a href={article.link} className="text-blue-500 underline">
+        Read original
+      </a>
+    </article>
+  )
+}

--- a/components/ui/article-list.tsx
+++ b/components/ui/article-list.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import * as React from 'react'
 import type { Article } from '@/lib/types'
 import ArticleCard from './article-card'
@@ -7,13 +9,11 @@ interface Props {
   onSelect?: (article: Article) => void
 }
 
-export default function ArticleList({ articles, onSelect }: Props) {
+export default function ArticleList({ articles }: Props) {
   return (
     <div className="space-y-4">
       {articles.map((article, idx) => (
-        <div key={idx} onClick={() => onSelect?.(article)}>
-          <ArticleCard article={article} />
-        </div>
+        <ArticleCard key={idx} article={article} />
       ))}
     </div>
   )

--- a/components/ui/article-list.tsx
+++ b/components/ui/article-list.tsx
@@ -1,0 +1,20 @@
+import * as React from 'react'
+import type { Article } from '@/lib/types'
+import ArticleCard from './article-card'
+
+interface Props {
+  articles: Article[]
+  onSelect?: (article: Article) => void
+}
+
+export default function ArticleList({ articles, onSelect }: Props) {
+  return (
+    <div className="space-y-4">
+      {articles.map((article, idx) => (
+        <div key={idx} onClick={() => onSelect?.(article)}>
+          <ArticleCard article={article} />
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/components/ui/error-boundary.tsx
+++ b/components/ui/error-boundary.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import * as React from 'react'
 
 interface State { hasError: boolean }

--- a/components/ui/error-boundary.tsx
+++ b/components/ui/error-boundary.tsx
@@ -1,0 +1,22 @@
+import * as React from 'react'
+
+interface State { hasError: boolean }
+
+export default class ErrorBoundary extends React.Component<React.PropsWithChildren, State> {
+  state: State = { hasError: false }
+
+  static getDerivedStateFromError() {
+    return { hasError: true }
+  }
+
+  componentDidCatch(error: any, info: any) {
+    console.error('ErrorBoundary caught error', error, info)
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return <div>Failed to load</div>
+    }
+    return this.props.children
+  }
+}

--- a/lib/rss-parser.ts
+++ b/lib/rss-parser.ts
@@ -1,0 +1,48 @@
+import Parser from 'rss-parser'
+import type { RSSResponse, Article } from './types'
+
+const parser = new Parser()
+
+export async function fetchWithRetry(
+  url: string,
+  options: RequestInit = {},
+  retries = 3,
+  timeoutMs = 5000
+): Promise<Response> {
+  let attempt = 0
+  let lastError: any
+
+  while (attempt < retries) {
+    const controller = new AbortController()
+    const id = setTimeout(() => controller.abort(), timeoutMs)
+    try {
+      const res = await fetch(url, { ...options, signal: controller.signal })
+      clearTimeout(id)
+      if (!res.ok) {
+        throw new Error(`HTTP ${res.status}`)
+      }
+      return res
+    } catch (err) {
+      lastError = err
+      clearTimeout(id)
+      attempt++
+      if (attempt >= retries) break
+      const backoff = Math.pow(2, attempt) * 100
+      await new Promise((r) => setTimeout(r, backoff))
+    }
+  }
+  throw lastError
+}
+
+export async function parseRss(url: string): Promise<RSSResponse> {
+  const response = await fetchWithRetry(url)
+  const text = await response.text()
+  const feed = await parser.parseString(text)
+  const items: Article[] = (feed.items || []).map((item) => ({
+    title: item.title || '',
+    link: item.link || '',
+    pubDate: item.pubDate || '',
+    content: (item as any).content || (item as any)['content:encoded'] || ''
+  }))
+  return { items }
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,0 +1,10 @@
+export interface Article {
+  title: string
+  link: string
+  pubDate: string
+  content?: string
+}
+
+export interface RSSResponse {
+  items: Article[]
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,8 +1,14 @@
 import { defineConfig } from 'vitest/config'
 import react from '@vitejs/plugin-react'
+import path from 'path'
 
 export default defineConfig({
   plugins: [react()],
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './')
+    }
+  },
   test: {
     environment: 'jsdom',
     setupFiles: ['vitest.setup.ts']

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,1 +1,4 @@
-import '@testing-library/jest-dom'
+import { expect } from 'vitest'
+import '@testing-library/jest-dom/vitest'
+
+export { expect }


### PR DESCRIPTION
## Summary
- define core article and RSS response types
- add RSS parsing utility with retry and timeout
- implement RSS API route with strict URL validation
- build article UI components and main page
- configure vitest for path alias and jest-dom

## Testing
- `npm test` *(fails: connect ENETUNREACH to ai-news.dev during network fetch)*

------
https://chatgpt.com/codex/tasks/task_e_68b9b1f06954832a995b3c7d4b3ad385

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 新機能
  - RSSフィード取得APIを追加し、許可ドメインのみから取得できるようにしました。
  - トップページで記事をサーバー側取得し、一覧として表示します。
  - 記事カード・一覧・詳細コンポーネントを追加し、見出し・公開日・本文を表示します。
  - 画面エラー時にフォールバックを表示するエラーバウンダリを導入しました。
- テスト
  - テスト環境をVitestに統一し、DOMマッチャーを有効化しました。
- チョア
  - インポート用のモジュールエイリアスを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->